### PR TITLE
Refactor: Avoid using `pytest.globalDict`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,22 +1,19 @@
-# pylint: disable=invalid-name
-# pylint: disable=protected-access
-# pylint: disable=wildcard-import
-# pylint: disable=unused-wildcard-import
-
-from collections import defaultdict
+import os
 
 from cucumber_tag_expressions import parse
+from dotenv import load_dotenv, find_dotenv
 
 from step_definitions.test_common import *
 from step_definitions.test_assertions import *
 
 from lib.terminal_report import pytest_terminal_summary
 
+load_dotenv(find_dotenv())
+
 
 def pytest_configure(config):
     config.option.keyword = "automated"
     config.option.markexpr = "not not_in_scope"
-    pytest.globalDict = defaultdict()
 
 
 def pytest_addoption(parser):
@@ -35,3 +32,9 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(scope="session")
 def context():
     return {}
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    """Fixture to set the Base URL from environment variable"""
+    return os.environ.get("BASE_URL")

--- a/tests/features/sample.feature
+++ b/tests/features/sample.feature
@@ -1,45 +1,45 @@
 @automated
 Feature: Test CRUD HTTP methods
-    As a user
-    I will send POST, GET, UPDATE, and DELETE requests
-    I want to be able to see the expected response
+  As a user
+  I will send POST, GET, UPDATE, and DELETE requests
+  I want to be able to see the expected response
 
-    Background:
-        Given I set sample "rest_api_base_url"
-        And I set the header param request content type as "application/json"
+  Background:
+    Given I set sample rest_api_base_url
+    And I set the header param request content type as "application/json"
 
-    @smoke
-    Scenario Outline: POST route
-        Given I set the POST endpoint to "/posts" for creating posts
-        When I send a POST HTTP request with <payload>
-        Then I expect the HTTP response code of "POST" to be "201"
-        And I expect the response body of "POST" to be non-empty
-        Examples:
-            |   payload             |
-            |   post_payload_1.json |
-            |   post_payload_2.json |
+  @smoke
+  Scenario Outline: POST route
+    Given I set the POST endpoint to "/posts" for creating posts
+    When I send a POST HTTP request with <payload>
+    Then I expect the HTTP response code of "POST" to be "201"
+    And I expect the response body of "POST" to be non-empty
+    Examples:
+      | payload             |
+      | post_payload_1.json |
+      | post_payload_2.json |
 
-    @smoke
-    Scenario: GET route
-        Given I set the GET endpoint to "/posts" for fetching posts
-        When I send a GET HTTP request
-        Then I expect the HTTP response code of "GET" to be "200"
-        And I expect the response body of "GET" to be non-empty
+  @smoke
+  Scenario: GET route
+    Given I set the GET endpoint to "/posts" for fetching posts
+    When I send a GET HTTP request
+    Then I expect the HTTP response code of "GET" to be "200"
+    And I expect the response body of "GET" to be non-empty
 
-    @smoke
-    Scenario Outline: UPDATE route
-        Given I set the UPDATE endpoint to "/posts/1" for updating posts
-        When I send a PUT HTTP request with <payload>
-        Then I expect the HTTP response code of "PUT" to be "200"
-        And I expect the response body of "PUT" to be non-empty
-        Examples:
-            |   payload             |
-            |   put_payload_1.json  |
-            |   put_payload_2.json  |
+  @smoke
+  Scenario Outline: UPDATE route
+    Given I set the UPDATE endpoint to "/posts/1" for updating posts
+    When I send a PUT HTTP request with <payload>
+    Then I expect the HTTP response code of "PUT" to be "200"
+    And I expect the response body of "PUT" to be non-empty
+    Examples:
+      | payload            |
+      | put_payload_1.json |
+      | put_payload_2.json |
 
-    @smoke
-    Scenario: DELETE route
-        Given I set the DELETE endpoint to "/posts/1" for deleting posts
-        When I send a DELETE HTTP request
-        Then I expect the HTTP response code of "DELETE" to be "200"
-        And I expect the response body of "DELETE" to be empty
+  @smoke
+  Scenario: DELETE route
+    Given I set the DELETE endpoint to "/posts/1" for deleting posts
+    When I send a DELETE HTTP request
+    Then I expect the HTTP response code of "DELETE" to be "200"
+    And I expect the response body of "DELETE" to be empty

--- a/tests/lib/terminal_report.py
+++ b/tests/lib/terminal_report.py
@@ -33,7 +33,9 @@ def _custom_short_summary(terminalreporter: TerminalReporter):
     for failed_test in failed_cases:
         write(f"\tFailed test: {failed_test.nodeid}\n", yellow=True)
 
-    write_sep("=", "End of Test Report Summary", red=failed, green=(not failed), bold=True)
+    write_sep(
+        "=", "End of Test Report Summary", red=failed, green=(not failed), bold=True
+    )
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/step_definitions/test_common.py
+++ b/tests/step_definitions/test_common.py
@@ -1,16 +1,11 @@
-import os
-
 import pytest
 from pytest_bdd import given, parsers
 
-from dotenv import load_dotenv, find_dotenv
 
-load_dotenv(find_dotenv())
-
-
-@given(parsers.parse('I set sample "{rest_api_base_url}"'))
-def set_rest_api_url():
-    pytest.globalDict["rest_api_base_url"] = os.environ.get("BASE_URL")
+@pytest.fixture
+@given("I set sample rest_api_base_url")
+def set_rest_api_base_url(base_url):
+    return base_url
 
 
 @pytest.fixture
@@ -23,6 +18,7 @@ def set_headers(header_content_type):
     return {"Content-type": f"{header_content_type}; charset=UTF-8"}
 
 
+@pytest.fixture
 @given(
     parsers.parse('I set the DELETE endpoint to "{endpoint_url}" for deleting posts')
 )
@@ -31,7 +27,6 @@ def set_headers(header_content_type):
 )
 @given(parsers.parse('I set the GET endpoint to "{endpoint_url}" for fetching posts'))
 @given(parsers.parse('I set the POST endpoint to "{endpoint_url}" for creating posts'))
-def set_api_endpoint(endpoint_url):
-    pytest.globalDict["api_endpoint"] = (
-        pytest.globalDict["rest_api_base_url"] + endpoint_url
-    )
+def set_api_endpoint(set_rest_api_base_url, endpoint_url):
+    api_endpoint = set_rest_api_base_url + endpoint_url
+    return api_endpoint

--- a/tests/step_definitions/test_sample.py
+++ b/tests/step_definitions/test_sample.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest_bdd import when, scenarios
 
 from utils.utils import (
@@ -13,30 +12,34 @@ scenarios("sample.feature")
 
 
 @when("I send a POST HTTP request with <payload>")
-def send_post_request(context, payload, set_headers):
+def send_post_request(context, payload, set_headers, set_api_endpoint):
     request_body = read_file(payload)
-    post_response = post_request(payload=request_body, headers=set_headers)
+    post_response = post_request(
+        api_endpoint=set_api_endpoint, payload=request_body, headers=set_headers
+    )
     context["post_response"] = post_response.json()
     context["post_status_code"] = post_response.status_code
 
 
 @when("I send a GET HTTP request")
-def send_get_request(context, set_headers):
-    get_response = get_request(headers=set_headers)
+def send_get_request(context, set_headers, set_api_endpoint):
+    get_response = get_request(api_endpoint=set_api_endpoint, headers=set_headers)
     context["get_response"] = get_response.json()
     context["get_status_code"] = get_response.status_code
 
 
 @when("I send a PUT HTTP request with <payload>")
-def send_put_request(context, payload, set_headers):
+def send_put_request(context, payload, set_headers, set_api_endpoint):
     request_body = read_file(payload)
-    put_response = put_request(payload=request_body, headers=set_headers)
+    put_response = put_request(
+        api_endpoint=set_api_endpoint, payload=request_body, headers=set_headers
+    )
     context["put_response"] = put_response.json()
     context["put_status_code"] = put_response.status_code
 
 
 @when("I send a DELETE HTTP request")
-def send_delete_request(context, set_headers):
-    delete_response = delete_request(headers=set_headers)
+def send_delete_request(context, set_headers, set_api_endpoint):
+    delete_response = delete_request(api_endpoint=set_api_endpoint, headers=set_headers)
     context["delete_response"] = delete_response.json()
     context["delete_status_code"] = delete_response.status_code

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -2,7 +2,6 @@ import json
 from pathlib import Path
 from typing import Dict
 
-import pytest
 import requests
 
 from utils.custom_exceptions import InvalidFileFormatException, FileNotFoundException
@@ -31,7 +30,7 @@ def get_file_path(file_name: str) -> Path:
 
 
 def make_request(
-        method: str, api_endpoint: str, headers: Dict = None, payload: Dict = None
+    method: str, api_endpoint: str, headers: Dict = None, payload: Dict = None
 ) -> requests.Response:
     """Make a request using the given method and log the request & response details."""
     response = session.request(method, api_endpoint, headers=headers, json=payload)
@@ -56,7 +55,7 @@ def get_request(api_endpoint: str = None, headers: Dict = None) -> requests.Resp
 
 
 def post_request(
-        api_endpoint: str = None, headers: Dict = None, payload: Dict = None
+    api_endpoint: str = None, headers: Dict = None, payload: Dict = None
 ) -> requests.Response:
     """Make a POST request."""
     return make_request(
@@ -65,7 +64,7 @@ def post_request(
 
 
 def put_request(
-        api_endpoint: str = None, headers: Dict = None, payload: Dict = None
+    api_endpoint: str = None, headers: Dict = None, payload: Dict = None
 ) -> requests.Response:
     """Make a PUT request."""
     return make_request(

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -1,6 +1,6 @@
 import json
-from typing import Dict
 from pathlib import Path
+from typing import Dict
 
 import pytest
 import requests
@@ -31,10 +31,9 @@ def get_file_path(file_name: str) -> Path:
 
 
 def make_request(
-    method: str, headers: Dict = None, payload: Dict = None
+        method: str, api_endpoint: str, headers: Dict = None, payload: Dict = None
 ) -> requests.Response:
     """Make a request using the given method and log the request & response details."""
-    api_endpoint = pytest.globalDict["api_endpoint"]
     response = session.request(method, api_endpoint, headers=headers, json=payload)
     log_details = "\n".join(
         [
@@ -51,21 +50,29 @@ def make_request(
     return response
 
 
-def get_request(headers: Dict = None) -> requests.Response:
+def get_request(api_endpoint: str = None, headers: Dict = None) -> requests.Response:
     """Make a GET request."""
-    return make_request("GET", headers=headers)
+    return make_request("GET", api_endpoint=api_endpoint, headers=headers)
 
 
-def post_request(headers: Dict = None, payload: Dict = None) -> requests.Response:
+def post_request(
+        api_endpoint: str = None, headers: Dict = None, payload: Dict = None
+) -> requests.Response:
     """Make a POST request."""
-    return make_request("POST", headers=headers, payload=payload)
+    return make_request(
+        "POST", api_endpoint=api_endpoint, headers=headers, payload=payload
+    )
 
 
-def put_request(headers: Dict = None, payload: Dict = None) -> requests.Response:
+def put_request(
+        api_endpoint: str = None, headers: Dict = None, payload: Dict = None
+) -> requests.Response:
     """Make a PUT request."""
-    return make_request("PUT", headers=headers, payload=payload)
+    return make_request(
+        "PUT", api_endpoint=api_endpoint, headers=headers, payload=payload
+    )
 
 
-def delete_request(headers: Dict = None) -> requests.Response:
+def delete_request(api_endpoint: str = None, headers: Dict = None) -> requests.Response:
     """Make a DELETE request."""
-    return make_request("DELETE", headers=headers)
+    return make_request("DELETE", api_endpoint=api_endpoint, headers=headers)


### PR DESCRIPTION
**Reason for the change**:
```text
Instead of using pytest.globalDict, it's usually better to use fixtures or other explicit means of passing data between test functions. This can help ensure that each test is run in a clean and isolated environment, which can make it easier to write reliable tests and diagnose issues when they arise.
```

**Changes**:

- Removed using `pytest.globalDict`
   - `pytest.globalDict = defaultdict()`
   - `pytest.globalDict["rest_api_base_url"] = os.environ.get("BASE_URL")`
   - `pytest.globalDict["api_endpoint"] = (pytest.globalDict["rest_api_base_url"] + endpoint_url)`
   - `api_endpoint = pytest.globalDict["api_endpoint"]`
- Used fixtures, other explicit means of passing data between test functions instead of using `pytest.globalDict`
- Updated particular BDD step
- Fixed formatting
- etc.,